### PR TITLE
Add support for bragg@^2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,17 @@ function invoke(method, async, fn, path, opts) {
 		'http-method': method
 	}, opts);
 
-	return lambda[async ? 'invokeAsync' : 'invoke'](fn, options).catch(error => {
+	return lambda[async ? 'invokeAsync' : 'invoke'](fn, options).then(result => {
+		if (result.body && result.headers && result.statusCode) {
+			try {
+				return JSON.parse(result.body);
+			} catch (error) {
+				return result.body;
+			}
+		}
+
+		return result;
+	}).catch(error => {
 		const parsedError = parseError(error);
 		parsedError.httpMethod = method.toUpperCase();
 		parsedError.function = fn;

--- a/index.js
+++ b/index.js
@@ -42,13 +42,13 @@ function invoke(method, async, fn, path, opts) {
 		'http-method': method
 	}, opts);
 
-	return lambda[async ? 'invokeAsync' : 'invoke'](fn, options).catch(err => {
-		const error = parseError(err);
-		error.httpMethod = method.toUpperCase();
-		error.function = fn;
-		error.path = path;
+	return lambda[async ? 'invokeAsync' : 'invoke'](fn, options).catch(error => {
+		const parsedError = parseError(error);
+		parsedError.httpMethod = method.toUpperCase();
+		parsedError.function = fn;
+		parsedError.path = path;
 
-		throw error;
+		throw parsedError;
 	});
 }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "aws-lambda-invoke": "^2.1.0"
   },
   "devDependencies": {
-    "ava": "*",
+    "ava": "^0.25.0",
     "aws-sdk": "^2.2.30",
     "sinon": "^1.17.2",
     "sinon-as-promised": "^4.0.0",

--- a/test.js
+++ b/test.js
@@ -8,6 +8,13 @@ test.before(() => {
 	const stub = sinon.stub(lambda, 'invoke');
 	stub.withArgs('foo', {'http-method': 'post', 'resource-path': 'bar', body: {foo: 'bar'}}).rejects('400 - Bad Request');
 	stub.withArgs('foo', {'http-method': 'post', 'resource-path': 'baz', body: {foo: 'baz'}}).rejects('Something went wrong');
+	stub.withArgs('foo', {'http-method': 'post', 'resource-path': 'bragg2/baz', body: {foo: 'baz'}}).resolves({
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		statusCode: 200,
+		body: '{"foo":"baz"}'
+	});
 	stub.resolves({foo: 'bar'});
 
 	const invokeAsync = sinon.stub(lambda, 'invokeAsync');
@@ -95,4 +102,8 @@ test('remote error without status code', async t => {
 		t.is(error.function, 'foo');
 		t.is(error.path, 'baz');
 	}
+});
+
+test.serial('invoke a bragg@^2.0.0 service', async t => {
+	t.deepEqual(await m.post('foo', 'bragg2/baz', {body: {foo: 'baz'}}), {foo: 'baz'});
 });

--- a/test.js
+++ b/test.js
@@ -1,13 +1,13 @@
 import test from 'ava';
 import sinon from 'sinon';
-import 'sinon-as-promised';
+import 'sinon-as-promised'; // eslint-disable-line import/no-unassigned-import
 import lambda from 'aws-lambda-invoke';
-import m from './';
+import m from '.';
 
 test.before(() => {
 	const stub = sinon.stub(lambda, 'invoke');
-	stub.withArgs('foo', {'http-method': 'post', 'resource-path': 'bar', 'body': {foo: 'bar'}}).rejects('400 - Bad Request');
-	stub.withArgs('foo', {'http-method': 'post', 'resource-path': 'baz', 'body': {foo: 'baz'}}).rejects('Something went wrong');
+	stub.withArgs('foo', {'http-method': 'post', 'resource-path': 'bar', body: {foo: 'bar'}}).rejects('400 - Bad Request');
+	stub.withArgs('foo', {'http-method': 'post', 'resource-path': 'baz', body: {foo: 'baz'}}).rejects('Something went wrong');
 	stub.resolves({foo: 'bar'});
 
 	const invokeAsync = sinon.stub(lambda, 'invokeAsync');
@@ -27,9 +27,9 @@ test('methods', t => {
 	t.truthy(m.deleteAsync);
 });
 
-test('error', t => {
-	t.throws(m.get(), 'Expected a function name');
-	t.throws(m.get('foo'), 'Expected a resource path');
+test('error', async t => {
+	await t.throws(m.get(), 'Expected a function name');
+	await t.throws(m.get('foo'), 'Expected a resource path');
 });
 
 test('result', async t => {
@@ -53,7 +53,7 @@ test.serial('invoke with params', async t => {
 	t.deepEqual(lambda.invoke.lastCall.args[1], {
 		'resource-path': '/foo',
 		'http-method': 'post',
-		'body': {
+		body: {
 			foo: 'bar'
 		}
 	});
@@ -66,7 +66,7 @@ test.serial('invoke async', async t => {
 	t.deepEqual(lambda.invokeAsync.lastCall.args[1], {
 		'resource-path': '/world',
 		'http-method': 'post',
-		'body': {
+		body: {
 			foo: 'bar'
 		}
 	});
@@ -76,12 +76,12 @@ test('remote error', async t => {
 	try {
 		await m.post('foo', 'bar', {body: {foo: 'bar'}});
 		t.fail('Expected to throw an error');
-	} catch (err) {
-		t.is(err.message, 'Bad Request');
-		t.is(err.status, 400);
-		t.is(err.httpMethod, 'POST');
-		t.is(err.function, 'foo');
-		t.is(err.path, 'bar');
+	} catch (error) {
+		t.is(error.message, 'Bad Request');
+		t.is(error.status, 400);
+		t.is(error.httpMethod, 'POST');
+		t.is(error.function, 'foo');
+		t.is(error.path, 'bar');
 	}
 });
 
@@ -89,10 +89,10 @@ test('remote error without status code', async t => {
 	try {
 		await m.post('foo', 'baz', {body: {foo: 'baz'}});
 		t.fail('Expected to throw an error');
-	} catch (err) {
-		t.is(err.message, 'Something went wrong');
-		t.is(err.httpMethod, 'POST');
-		t.is(err.function, 'foo');
-		t.is(err.path, 'baz');
+	} catch (error) {
+		t.is(error.message, 'Something went wrong');
+		t.is(error.httpMethod, 'POST');
+		t.is(error.function, 'foo');
+		t.is(error.path, 'baz');
 	}
 });


### PR DESCRIPTION
Currently `bragg-route-invoke:^1.0.0` cannot handle requests which come from a `bragg@^2.0.0`.

This is the first step in order to make `bragg-route-invoke` and `bragg` compatible with both versions.

TODO:

- [ ] @SamVerschueren you should create a new branch on the latest commit containing v1 code (b4cf4797f8d20cd9b90333676c19ea3f1f8f216c)
- [ ] I then need to update this PR to merge in the new branch